### PR TITLE
Send a function instead of a function name in the setCallbackFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ service for the Google Drive API.
           // Set the project key of the script using this library.
           .setProjectKey('...')
 
-          // Set the name of the callback function in the script referenced
-          // above that should be invoked to complete the OAuth flow.
-          .setCallbackFunction('authCallback')
+          // Set the callback function in the script referenced above that
+          // should be invoked to complete the OAuth flow.
+          .setCallbackFunction(authCallback)
 
           // Set the property store where authorized tokens should be persisted.
           .setPropertyStore(PropertiesService.getUserProperties())

--- a/Service.gs
+++ b/Service.gs
@@ -85,11 +85,11 @@ Service_.prototype.setProjectKey = function(projectKey) {
  * called when the user completes the authorization flow on the service provider's website.
  * The callback accepts a request parameter, which should be passed to this service's
  * <code>handleCallback()</code> method to complete the process.
- * @param {string} callbackFunctionName The name of the callback function.
+ * @param {Object} callbackFunction The callback function.
  * @return {Service_} This service, for chaining.
  */
-Service_.prototype.setCallbackFunction = function(callbackFunctionName) {
-  this.callbackFunctionName_ = callbackFunctionName;
+Service_.prototype.setCallbackFunction = function(callbackFunction) {
+  this.callbackFunction_ = callbackFunction;
   return this;
 };
 
@@ -182,13 +182,13 @@ Service_.prototype.getAuthorizationUrl = function() {
   validate_({
     'Client ID': this.clientId_,
     'Project key': this.projectKey_,
-    'Callback function name': this.callbackFunctionName_,
+    'Callback function name': this.callbackFunction_,
     'Authorization base URL': this.authorizationBaseUrl_
   });
 
   var redirectUri = getRedirectUri(this.projectKey_);
   var state = ScriptApp.newStateToken()
-      .withMethod(this.callbackFunctionName_)
+      .withMethod(this.callbackFunction_)
       .withArgument('serviceName', this.serviceName_)
       .withTimeout(3600)
       .createToken();


### PR DESCRIPTION
I propose send a function instead of a function name in the `setCallbackFunction`. Why? To have the possibility of having the `authCallback` function in another scope.

Example:

```javascript
var Signature = (function () {
    var _scope = 'https://apps-apis.google.com/a/feeds/emailsettings/2.0/';

    function _authCallback (request) { ... }

    return {
        buildUrl: function (email) { ... },

        getService: function () {
            return OAuth2.createService('signature')
                ...
                .setCallbackFunction(_authCallback)
                ...
        }
    }
})();

var signatureService = Signature.getService();
```