### PR TITLE
typeof test of a gulp-expose varables

### DIFF
--- a/src/OAuth2.gs
+++ b/src/OAuth2.gs
@@ -61,7 +61,7 @@ function getRedirectUri(scriptId) {
   return Utilities.formatString('https://script.google.com/macros/d/%s/usercallback', scriptId);
 }
 
-if (module) {
+if (typeof module === 'object') {
   module.exports = {
     createService: createService,
     getRedirectUri: getRedirectUri


### PR DESCRIPTION
The dist task uses gulp-expose, which should create a modules variables. The typeof test allows to stay the code unchanged after the dist task