### PR TITLE
Added the original YDN url for to try faster.

### DIFF
--- a/samples/Yahoo.gs
+++ b/samples/Yahoo.gs
@@ -14,7 +14,7 @@ var CLIENT_SECRET = '...';
 function run() {
   var service = getService();
   if (service.hasAccess()) {
-    var url = 'https://social.yahooapis.com/v1/user/abcdef123/profile?format=json';
+    var url = 'https://social.yahooapis.com/v1/user/me/profile?format=json';
     var response = UrlFetchApp.fetch(url, {
       headers: {
         'Authorization': 'Bearer ' + service.getAccessToken()


### PR DESCRIPTION
When I tried to return to the test of the example #61, I found that it would be more convenient to use a different url without additional parameter search.