### PR TITLE
Fix Bug in `getTokenFromResponse_` for APIs that Respond with 201 Created

### DIFF
--- a/dist/OAuth2.gs
+++ b/dist/OAuth2.gs
@@ -27,7 +27,7 @@
 
 /**
  * The supported formats for the returned OAuth2 token.
- * @type {Object.<string, string>
+ * @type {Object.<string, string>}
  */
 var TOKEN_FORMAT = {
   JSON: 'application/json',
@@ -65,7 +65,7 @@ function getRedirectUri(scriptId) {
   return Utilities.formatString('https://script.google.com/macros/d/%s/usercallback', scriptId);
 }
 
-if (module) {
+if (typeof module === 'object') {
   module.exports = {
     createService: createService,
     getRedirectUri: getRedirectUri
@@ -466,7 +466,8 @@ Service_.prototype.getRedirectUri = function() {
  */
 Service_.prototype.getTokenFromResponse_ = function(response) {
   var token = this.parseToken_(response.getContentText());
-  if (response.getResponseCode() != 200 || token.error) {
+  var resCode = response.getResponseCode();
+  if ( !(resCode >= 200 && resCode < 300) || token.error) {
     var reason = [
       token.error,
       token.message,
@@ -476,7 +477,7 @@ Service_.prototype.getTokenFromResponse_ = function(response) {
       return typeof(part) == 'string' ? part : JSON.stringify(part);
     }).join(', ');
     if (!reason) {
-      reason = response.getResponseCode() + ': ' + JSON.stringify(token);
+      reason = resCode + ': ' + JSON.stringify(token);
     }
     throw 'Error retrieving token: ' + reason;
   }

--- a/samples/Medium.gs
+++ b/samples/Medium.gs
@@ -1,0 +1,74 @@
+var CLIENT_ID;
+var CLIENT_SECRET;
+
+/**
+ * Authorizes and makes a request to the Medium API.
+ */
+function run() {
+  var service = getService_();
+  if (service.hasAccess()) {
+    var url = 'https://api.medium.com/v1/me';
+    var response = UrlFetchApp.fetch(url, {
+      headers: {
+        Authorization: 'Bearer ' + service.getAccessToken()
+      }
+    });
+    var result = JSON.parse(response.getContentText());
+    Logger.log(JSON.stringify(result, null, 2));
+  } else {
+    var authorizationUrl = service.getAuthorizationUrl();
+    Logger.log('Open the following URL and re-run the script: %s',
+        authorizationUrl);
+  }
+}
+
+/**
+ * Reset the authorization state, so that it can be re-tested.
+ */
+function reset() {
+  var service = getService_();
+  service.reset();
+}
+
+
+/**
+ * Configures the service.
+ * Three required parameters are not specified because
+ * the library creates the authorization URL with them
+ * automatically: `redirect_url`, `response_type`, and
+ * `state`.
+ */
+function getService_() {
+
+  return OAuth2.createService('Medium')
+      // Set the endpoint URLs.
+      .setAuthorizationBaseUrl('https://medium.com/m/oauth/authorize')
+      .setTokenUrl('https://api.medium.com/v1/tokens')
+
+      // Set the client ID and secret.
+      .setClientId(CLIENT_ID)
+      .setClientSecret(CLIENT_SECRET)
+
+      // Set the name of the callback function that should be invoked to complete
+      // the OAuth flow.
+      .setCallbackFunction('authCallback_')
+
+      // Set the property store where authorized tokens should be persisted.
+      .setPropertyStore(PropertiesService.getUserProperties())
+
+      // Set scope (required)
+      .setScope('basicProfile');
+}
+
+/**
+ * Handles the OAuth callback.
+ */
+function authCallback_(request) {
+  var service = getService_();
+  var authorized = service.handleCallback(request);
+  if (authorized) {
+    return HtmlService.createHtmlOutput('Success!');
+  } else {
+    return HtmlService.createHtmlOutput('Denied');
+  }
+}

--- a/samples/Strava.gs
+++ b/samples/Strava.gs
@@ -1,0 +1,70 @@
+var CLIENT_ID;
+var CLIENT_SECRET;
+
+/**
+ * Authorizes and makes a request to the Strava API.
+ */
+function run() {
+  var service = getService_();
+  if (service.hasAccess()) {
+    var url = 'https://www.strava.com/api/v3/activities';
+    var response = UrlFetchApp.fetch(url, {
+      headers: {
+        Authorization: 'Bearer ' + service.getAccessToken()
+      }
+    });
+    var result = JSON.parse(response.getContentText());
+    Logger.log(JSON.stringify(result, null, 2));
+  } else {
+    var authorizationUrl = service.getAuthorizationUrl();
+    Logger.log('Open the following URL and re-run the script: %s',
+        authorizationUrl);
+  }
+}
+
+/**
+ * Reset the authorization state, so that it can be re-tested.
+ */
+function reset() {
+  var service = getService_();
+  service.reset();
+}
+
+/**
+ * Configures the service.
+ * Three required and optional parameters are not specified
+ * because the library creates the authorization URL with them
+ * automatically: `redirect_url`, `response_type`, and
+ * `state`.
+ */
+function getService_() {
+
+  return OAuth2.createService('Strava')
+      // Set the endpoint URLs.
+      .setAuthorizationBaseUrl('https://www.strava.com/oauth/authorize')
+      .setTokenUrl('https://www.strava.com/oauth/token')
+
+      // Set the client ID and secret.
+      .setClientId(CLIENT_ID)
+      .setClientSecret(CLIENT_SECRET)
+
+      // Set the name of the callback function that should be invoked to complete
+      // the OAuth flow.
+      .setCallbackFunction('authCallback_')
+
+      // Set the property store where authorized tokens should be persisted.
+      .setPropertyStore(PropertiesService.getUserProperties());
+}
+
+/**
+ * Handles the OAuth callback.
+ */
+function authCallback_(request) {
+  var service = getService_();
+  var authorized = service.handleCallback(request);
+  if (authorized) {
+    return HtmlService.createHtmlOutput('Success!');
+  } else {
+    return HtmlService.createHtmlOutput('Denied');
+  }
+}

--- a/src/Service.gs
+++ b/src/Service.gs
@@ -392,7 +392,8 @@ Service_.prototype.getRedirectUri = function() {
  */
 Service_.prototype.getTokenFromResponse_ = function(response) {
   var token = this.parseToken_(response.getContentText());
-  if (response.getResponseCode() != 200 || token.error) {
+  var resCode = response.getResponseCode();
+  if ( resCode < 200 || resCode >= 300 || token.error) {
     var reason = [
       token.error,
       token.message,
@@ -402,7 +403,7 @@ Service_.prototype.getTokenFromResponse_ = function(response) {
       return typeof(part) == 'string' ? part : JSON.stringify(part);
     }).join(', ');
     if (!reason) {
-      reason = response.getResponseCode() + ': ' + JSON.stringify(token);
+      reason = resCode + ': ' + JSON.stringify(token);
     }
     throw 'Error retrieving token: ' + reason;
   }


### PR DESCRIPTION
I tried using this library to connecting Google Apps Script and the [Medium API](https://github.com/Medium/medium-api-docs), and `getTokenFromResponse_` throws an error despite getting a successful response. The function currently throws an error if the response code isn't 200, but successful access token response from Medium have a 201 status code. So I modified that check to throw an error if the status code is outside of the entire 2xx success range.

This PR also includes examples for connecting to [Strava](https://strava.github.io/api/) and Medium.