### PR TITLE
Upon service reset, also clear the cached token

### DIFF
--- a/src/Service.gs
+++ b/src/Service.gs
@@ -362,7 +362,11 @@ Service_.prototype.reset = function() {
   validate_({
     'Property store': this.propertyStore_
   });
-  this.propertyStore_.deleteProperty(this.getPropertyKey_(this.serviceName_));
+  var key = this.getPropertyKey_(this.serviceName_);
+  this.propertyStore_.deleteProperty(key);
+  if (this.cache_) {
+    this.cache_.remove(key);
+  }
 };
 
 /**


### PR DESCRIPTION
If a cache is set then a token is acquired it is stored in both the Cache service and the Properties service. Therefore, when the Service is reset the token must be removed from the Cache service as well as the Properties service. Otherwise, getAccessToken() would still return the cached token after a call to reset().